### PR TITLE
cleanup source_urls

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
@@ -22,7 +22,7 @@ sources = [
 ]
 
 source_urls = [
-    'http://files.qe-forge.org/index.php?file=',  # others
+    'http://files.qe-forge.org/index.php?file=',  # all sources, except espresso*.tar.gz and GWW*.tar.gz
     'http://www.qe-forge.org/gf/download/frsrelease/185/753/',  # espresso-5.1.2.tar.gz
     'http://www.qe-forge.org/gf/download/frsrelease/185/754/',  # GWW-5.1.2.tar.gz
 ]

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.1.2-ictce-7.3.5.eb
@@ -22,14 +22,9 @@ sources = [
 ]
 
 source_urls = [
+    'http://files.qe-forge.org/index.php?file=',  # others
     'http://www.qe-forge.org/gf/download/frsrelease/185/753/',  # espresso-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/752/',  # atomic-5.1.2.tar.gz
     'http://www.qe-forge.org/gf/download/frsrelease/185/754/',  # GWW-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/755/',  # PHonon-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/756/',  # pwcond-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/757/',  # xspectra-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/758/',  # tddfpt-5.1.2.tar.gz
-    'http://www.qe-forge.org/gf/download/frsrelease/185/760/',  # neb-5.1.2.tar.gz
 ]
 
 buildopts = 'all plumed w90 want gipaw'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/1644

The generic download URL works for most tarballs, so include it and try that one first.

The generic URL doesn't work for both the `espresso` and `GWW` download URL though, so a workaround as implemented in https://github.com/hpcugent/easybuild-easyblocks/pull/618 is still required for this easyconfig.