### PR TITLE
Clang-10.0.0: add patch for libcxx on pc64le

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-10.0.0-GCCcore-8.3.0.eb
@@ -33,7 +33,7 @@ sources = [
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
 ]
-# patches = ['libcxx-%(version)s-ppc64le.patch']
+patches = ['libcxx-%(version)s-ppc64le.patch']
 checksums = [
     'df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf',  # llvm-10.0.0.src.tar.xz
     '885b062b00e903df72631c5f98b9579ed1ed2790f74e5646b4234fa084eacb21',  # clang-10.0.0.src.tar.xz

--- a/easybuild/easyconfigs/c/Clang/libcxx-10.0.0-ppc64le.patch
+++ b/easybuild/easyconfigs/c/Clang/libcxx-10.0.0-ppc64le.patch
@@ -1,0 +1,16 @@
+Reverse the if def order. Patch from https://bugs.llvm.org/show_bug.cgi?id=39696#c38
+Prepared for EasyBuild by Simon Branford, University of Birmingham
+--- a/projects/libcxx/include/thread.orig	2020-03-23 16:01:02.000000000 +0100
++++ b/projects/libcxx/include/thread	2020-04-08 19:19:31.625082029 +0200
+@@ -369,9 +369,9 @@
+     {
+ #if defined(_LIBCPP_COMPILER_GCC) && (__powerpc__ || __POWERPC__)
+     //  GCC's long double const folding is incomplete for IBM128 long doubles.
+-        _LIBCPP_CONSTEXPR duration<long double> _Max = nanoseconds::max();
+-#else
+         _LIBCPP_CONSTEXPR duration<long double> _Max = duration<long double>(ULLONG_MAX/1000000000ULL) ;
++#else
++        _LIBCPP_CONSTEXPR duration<long double> _Max = nanoseconds::max();
+ #endif
+         nanoseconds __ns;
+         if (__d < _Max)


### PR DESCRIPTION
I checked and the patch for libcxx on ppc still applies. I updated it for Clang v10 and reapplied it to the easyconfig. Even if you don't have any machine to test it, your builds on x86_64 won't be affected. Let me know if there is any issue with this PR.