### PR TITLE
Update sources of all easyconfigs of tbb using the github project

### DIFF
--- a/easybuild/easyconfigs/t/tbb/tbb-2017_U5-GCCcore-5.4.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2017_U5-GCCcore-5.4.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '5.4.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b785e7181317350f0bb20f7bffda20bdecde7e82b824d2e5eb6d408a3b9cbeaf',

--- a/easybuild/easyconfigs/t/tbb/tbb-2017_U5-foss-2016b.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2017_U5-foss-2016b.eb
@@ -9,7 +9,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'foss', 'version': '2016b'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b785e7181317350f0bb20f7bffda20bdecde7e82b824d2e5eb6d408a3b9cbeaf',

--- a/easybuild/easyconfigs/t/tbb/tbb-2017_U5-intel-2017a.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2017_U5-intel-2017a.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b785e7181317350f0bb20f7bffda20bdecde7e82b824d2e5eb6d408a3b9cbeaf',

--- a/easybuild/easyconfigs/t/tbb/tbb-2017_U6-GCCcore-6.3.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2017_U6-GCCcore-6.3.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '6.3.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b0f40edd010b90ce2519c1cebfa6f33216a1828d4fba19291b5cd23bd7fe809b',

--- a/easybuild/easyconfigs/t/tbb/tbb-2017_U6-intel-2017a.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2017_U6-intel-2017a.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'intel', 'version': '2017a'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b0f40edd010b90ce2519c1cebfa6f33216a1828d4fba19291b5cd23bd7fe809b',

--- a/easybuild/easyconfigs/t/tbb/tbb-2018_U1-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2018_U1-GCCcore-6.4.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('a9f51e0d081fbdda441d0150e759c7562318d6d7bc5a0c9a9d8064217d4d8d8d',

--- a/easybuild/easyconfigs/t/tbb/tbb-2018_U2-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2018_U2-GCCcore-6.4.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('733c4dba646573b8285b1923dc106f0d771725bea620baa3659c86ab9312a1f4',

--- a/easybuild/easyconfigs/t/tbb/tbb-2018_U3-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2018_U3-GCCcore-6.4.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('e5f19d747f6adabfc7daf2cc0a1ddcfab0f26bc083d70ea0a63def4a9f3919c5',

--- a/easybuild/easyconfigs/t/tbb/tbb-2018_U5-GCCcore-6.4.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2018_U5-GCCcore-6.4.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '6.4.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b8dbab5aea2b70cf07844f86fa413e549e099aa3205b6a04059ca92ead93a372',

--- a/easybuild/easyconfigs/t/tbb/tbb-2018_U5-GCCcore-7.3.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2018_U5-GCCcore-7.3.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '7.3.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('b8dbab5aea2b70cf07844f86fa413e549e099aa3205b6a04059ca92ead93a372',

--- a/easybuild/easyconfigs/t/tbb/tbb-2019_U4-GCCcore-8.2.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2019_U4-GCCcore-8.2.0.eb
@@ -7,7 +7,7 @@ description = """Intel(R) Threading Building Blocks (Intel(R) TBB) lets you easi
 
 toolchain = {'name': 'GCCcore', 'version': '8.2.0'}
 
-source_urls = ['https://github.com/01org/tbb/archive/']
+source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
     ('673e540aba6e526b220cbeacc3e4ff7b19a8689a00d7a09a9dc94396d73b24df',

--- a/easybuild/easyconfigs/t/tbb/tbb-2019_U9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/tbb/tbb-2019_U9-GCCcore-8.3.0.eb
@@ -10,7 +10,8 @@ toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 source_urls = ['https://github.com/oneapi-src/oneTBB/archive/']
 sources = ['%(version)s.tar.gz']
 checksums = [
-    '3f5ea81b9caa195f1967a599036b473b2e7c347117330cda99b79cfcf5b77c84'
+    ('15652f5328cf00c576f065e5cd3eaf3317422fe82afb67a9bcec0dc065bd2abe',
+     '3f5ea81b9caa195f1967a599036b473b2e7c347117330cda99b79cfcf5b77c84'),
 ]
 
 builddependencies = [


### PR DESCRIPTION
Since the old github project for TBB does not exist any more, we have to update the sources of all affected easyconfigs. Do you mind adding this to your PR?

Checksums should not be changed because many users will have already downloaded the old sources of TBB and those have to be still usable.